### PR TITLE
Set default environment to production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# For Sinatra configuration, defaults to production. 
+# For local development, set this value to development
+APP_ENV=production
+
 TWILIO_ACCOUNT_SID=
 TWILIO_API_KEY=
 TWILIO_API_SECRET=

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ bundle exec ruby app.rb
 
 To generate Access Token, visit [http://localhost:4567?identity=alice&room=example](http://localhost:4567?identity=alice&room=example).
 
+### Configure Development vs Production Settings
+
+By default, this application will run in production mode - stack traces will not be visible in the web browser. If you would like to run this application in development locally, change the `APP_ENV` variable in your `.env` file.
+
+`APP_ENV=development`
+
+For more about development vs production, visit [Sinatra's configuration page](http://sinatrarb.com/configuration.html).
 
 ## License
 

--- a/app.rb
+++ b/app.rb
@@ -5,6 +5,11 @@ require 'dotenv'
 # Load environment configuration
 Dotenv.load
 
+# Set the environment after dotenv loads
+# Default to production
+environment = (ENV['APP_ENV'] || ENV['RACK_ENV'] || :production).to_sym
+set :environment, environment
+
 # Generate a token for use in our Video application
 get '/' do
   identity = params[:identity] || 'identity'


### PR DESCRIPTION
Set default environment to production.

Changes in the PR:

- Set `APP_ENV` to `production`
- Update README.
